### PR TITLE
[Service] クエスト強制終了時のAPIを追加

### DIFF
--- a/src/controller/quest/quest_controller.ts
+++ b/src/controller/quest/quest_controller.ts
@@ -7,6 +7,7 @@ import {
   GetQuestResponse,
   StartQuestResponse,
   FinishQuestResponse,
+  ForceFinishQuestResponse,
 } from "../quest/response";
 import { verifyToken } from "../../utils/jwt";
 import { createQuestService } from "../../service/quest/create_quest_service";
@@ -18,6 +19,7 @@ import { finishQuestService } from "../../service/quest/finish_quest_service";
 import { CustomError } from "../../pkg/customError";
 import { JwtPayload } from "jsonwebtoken";
 import { Quest } from "../../model/quest/types";
+import { forceFinishQuestService } from "../../service/quest/force_finish_quest_service";
 
 // クエストの作成
 export const createQuestController = async (req: Request<{}, {}, CreateQuestRequest>, res: Response) => {
@@ -208,6 +210,39 @@ export const finishQuestController = async (req: Request<{ id: string }>, res: R
   try {
     const outputDTO = await finishQuestService(inputDTO);
     const response: FinishQuestResponse = {
+      status: "ok",
+      id: outputDTO.id,
+      title: outputDTO.title,
+      description: outputDTO.description,
+      starts_at: outputDTO.startsAt,
+      started_at: outputDTO.startedAt,
+      minutes: outputDTO.minutes,
+      tag_id: outputDTO.tagId,
+      difficulty: outputDTO.difficulty,
+      state: outputDTO.state,
+      is_succeeded: outputDTO.isSucceeded,
+      continuation_level: outputDTO.continuationLevel,
+      start_date: outputDTO.startDate,
+      end_date: outputDTO.endDate,
+      dates: outputDTO.dates,
+      weekly_frequency: outputDTO.weeklyFrequency,
+      weekly_completion_count: outputDTO.weeklyCompletionCount,
+      total_completion_count: outputDTO.totalCompletionCount,
+    };
+    return res.status(200).json(response);
+  } catch (err) {
+    if (err instanceof CustomError) {
+      return res.status(err.statusCode).json({ status: "error", message: err.message });
+    }
+    return res.status(500).json({ status: "error", message: "Internal server error." });
+  }
+};
+
+export const forceFinishQuestController = async (req: Request<{ id: string }>, res: Response) => {
+  const inputDTO = { id: req.params.id };
+  try {
+    const outputDTO = await forceFinishQuestService(inputDTO);
+    const response: ForceFinishQuestResponse = {
       status: "ok",
       id: outputDTO.id,
       title: outputDTO.title,

--- a/src/controller/quest/response.ts
+++ b/src/controller/quest/response.ts
@@ -104,3 +104,24 @@ export type FinishQuestResponse = {
   weekly_completion_count: number;
   total_completion_count: number;
 };
+
+export type ForceFinishQuestResponse = {
+  status: string;
+  id: string;
+  title: string;
+  description: string;
+  starts_at: string;
+  started_at: string;
+  minutes: number;
+  tag_id: string;
+  difficulty: string;
+  state: string;
+  is_succeeded: boolean;
+  continuation_level: number;
+  start_date: Date;
+  end_date: Date;
+  dates: string[];
+  weekly_frequency: number;
+  weekly_completion_count: number;
+  total_completion_count: number;
+};

--- a/src/model/quest/quest_model.ts
+++ b/src/model/quest/quest_model.ts
@@ -15,7 +15,7 @@ const getCurrentDateTime = () => {
   const seconds = String(now.getSeconds()).padStart(2, '0');
 
   // フォーマットされた文字列を返す
-  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`; 
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 };
 
 const create = async (
@@ -130,7 +130,6 @@ const getByUserId = async (userId: string): Promise<Quest[] | null> => {
 
 const startById = async (id: string): Promise<Quest | null> => {
   const quest: Prisma.QuestUpdateInput = {
-    id: id,
     startedAt: getCurrentDateTime(),
   };
   const result = await prisma.quest.update({ where: { id: id }, data: quest });
@@ -139,7 +138,6 @@ const startById = async (id: string): Promise<Quest | null> => {
 
 const finishById = async (id: string): Promise<Quest | null> => {
   const quest: Prisma.QuestUpdateInput = {
-    id: id,
     isSucceeded: true,
     state: "ACTIVE",
     continuationLevel: { increment: 1 },
@@ -150,6 +148,16 @@ const finishById = async (id: string): Promise<Quest | null> => {
   const result = await prisma.quest.update({ where: { id: id }, data: quest });
   return result;
 };
+
+const forceFinishById = async (id: string): Promise<Quest> => {
+  const quest: Prisma.QuestUpdateInput = {
+    isSucceeded: false,
+    state: "ACTIVE"
+  }
+
+  const result = await prisma.quest.update({ where: { id: id }, data: quest })
+  return result
+}
 
 // const handlePrismaError = (err) => {
 //   switch (err.code) {
@@ -176,4 +184,5 @@ export const questModel = {
   deleteById,
   startById,
   finishById,
+  forceFinishById
 };

--- a/src/route/quest.ts
+++ b/src/route/quest.ts
@@ -6,6 +6,7 @@ import {
   getQuestController,
   startQuestController,
   finishQuestController,
+  forceFinishQuestController,
 } from "../controller/quest/quest_controller";
 import { body } from "express-validator";
 import { validate } from "../pkg/validate";
@@ -31,4 +32,5 @@ questRouter.delete("/:id", auth, deleteQuestController);
 questRouter.get("/", auth, getQuestController);
 questRouter.patch("/start/:id", auth, startQuestController);
 questRouter.patch("/finish/:id", auth, finishQuestController);
+questRouter.patch("/force-finish/:id", auth, forceFinishQuestController);
 export { questRouter };

--- a/src/service/quest/finish_quest_service.ts
+++ b/src/service/quest/finish_quest_service.ts
@@ -31,6 +31,5 @@ export const finishQuestService = async (inputDTO: inputDTO) => {
     weeklyFrequency: finishedQuest.weeklyFrequency,
     weeklyCompletionCount: finishedQuest.weeklyCompletionCount,
     totalCompletionCount: finishedQuest.totalCompletionCount,
-    userId: finishedQuest.userId,
   };
 };

--- a/src/service/quest/force_finish_quest_service.ts
+++ b/src/service/quest/force_finish_quest_service.ts
@@ -1,0 +1,35 @@
+import { questModel } from "../../model/quest/quest_model";
+import { CustomError } from "../../pkg/customError";
+type inputDTO = { id: string };
+
+export const forceFinishQuestService = async (inputDTO: inputDTO) => {
+  const model = questModel;
+  const quest = await model.getById(inputDTO.id);
+  if (!quest) {
+    throw new CustomError("指定したidのクエストが存在しません", 400);
+  }
+  const forceFinishedQuest = await model.forceFinishById(inputDTO.id);
+  if (!forceFinishedQuest) {
+    throw new CustomError("クエストの完了に失敗しました", 500);
+  }
+
+  return {
+    id: forceFinishedQuest.id,
+    title: forceFinishedQuest.title,
+    description: forceFinishedQuest.description,
+    startsAt: forceFinishedQuest.startsAt,
+    startedAt: forceFinishedQuest.startedAt,
+    minutes: forceFinishedQuest.minutes,
+    tagId: forceFinishedQuest.tagId,
+    difficulty: forceFinishedQuest.difficulty,
+    state: forceFinishedQuest.state,
+    isSucceeded: forceFinishedQuest.isSucceeded,
+    continuationLevel: forceFinishedQuest.continuationLevel,
+    startDate: forceFinishedQuest.startDate,
+    endDate: forceFinishedQuest.endDate,
+    dates: forceFinishedQuest.dates,
+    weeklyFrequency: forceFinishedQuest.weeklyFrequency,
+    weeklyCompletionCount: forceFinishedQuest.weeklyCompletionCount,
+    totalCompletionCount: forceFinishedQuest.totalCompletionCount,
+  };
+};

--- a/src/service/quest/start_quest_service.ts
+++ b/src/service/quest/start_quest_service.ts
@@ -31,6 +31,5 @@ export const startQuestService = async (inputDTO: inputDTO) => {
     weeklyFrequency: startedQuest.weeklyFrequency,
     weeklyCompletionCount: startedQuest.weeklyCompletionCount,
     totalCompletionCount: startedQuest.totalCompletionCount,
-    userId: startedQuest.userId,
   };
 };


### PR DESCRIPTION
## 関連 issue

## 説明
- クエストのスタートし忘れ、完了し忘れ時の強制終了（失敗）のAPIを作成しました。

## 動作確認手順
```
// PATCH http://localhost:3000/v1/quests/force-finish/:id

response
{
    "status": "ok",
    "id": "b8ba406a-cb02-46d2-9b4e-f639c957a5ce",
    "title": "Sample Quest4",
    "description": "This is a sample quest3.",
    "starts_at": "20:30:00",
    "started_at": "NOT_STARTED_YET",
    "minutes": 10,
    "tag_id": "tag_id",
    "difficulty": "DIFF",
    "state": "INACTIVE",
    "is_succeeded": false,
    "continuation_level": 3,
    "start_date": "2024-02-24T10:10:37.794Z",
    "end_date": "2024-02-24T15:00:00.000Z",
    "dates": [
        "TUE",
        "WEB",
        "SUN"
    ],
    "weekly_frequency": 3,
    "weekly_completion_count": 2,
    "total_completion_count": 2
}
```
## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
