### PR TITLE
feat:最低継続レベルを0->1に変更

### DIFF
--- a/src/model/quest/quest_model.ts
+++ b/src/model/quest/quest_model.ts
@@ -145,7 +145,7 @@ export class QuestModel {
     const updatedQuest: Prisma.QuestUpdateInput = {
       isSucceeded: false,
       state: "ACTIVE",
-      continuationLevel: 0,
+      continuationLevel: 1,
     };
     const result = await prisma.quest.update({
       where: { id: id },


### PR DESCRIPTION
## 関連 issue
#40 
## 説明

## 動作確認手順
クエスト一覧で、最低継続レベルが0->1になっているか確認してください


## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
