### PR TITLE
fix: 終了した週に対してのみsummaryを生成するように修正

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,7 +7,7 @@ import { allowCrossDomain } from "./core/cors";
 import { logger } from "./pkg/logger";
 import { cronQuestModel } from "./cron-job/quest";
 import { cronWeeklyReportModel } from "./cron-job/weeklyReport";
-import { requestLogger } from "./route/middlewares/requestsLogger";
+import { requestsLogger } from "./route/middlewares/requestsLogger";
 
 const app = express();
 
@@ -17,7 +17,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // Logger
-app.use(requestLogger);
+app.use(requestsLogger);
 
 // cors
 app.use(allowCrossDomain);

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import { allowCrossDomain } from "./core/cors";
 import { logger } from "./pkg/logger";
 import { cronQuestModel } from "./cron-job/quest";
 import { cronWeeklyReportModel } from "./cron-job/weeklyReport";
+import { requestLogger } from "./route/middlewares/requestsLogger";
 
 const app = express();
 
@@ -14,6 +15,9 @@ app.use(cookie());
 app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+
+// Logger
+app.use(requestLogger);
 
 // cors
 app.use(allowCrossDomain);

--- a/src/cron-job/quest.ts
+++ b/src/cron-job/quest.ts
@@ -1,7 +1,7 @@
 import cron from "node-cron";
 import { prisma } from "../db/db";
 import { logger } from "../pkg/logger";
-import { getStartAndEndJstDateTime } from "../model/funcs/dateTime";
+import { getStartAndEndUtcDateTime } from "../model/funcs/dateTime";
 
 const updateEveryDay = () => {
   const scheduledTime = process.env.CRON_TZ === "UTC" ? "59 59 14 * * *" : "59 59 23 * * *";
@@ -26,11 +26,11 @@ const updateEverySunday = () => {
   cron.schedule(scheduledTime, async () => {
     await prisma.$transaction(async (tx) => {
       logger.info("Running cron job for updating quests every Sunday.");
-      const { dateNowJst, nextSundayJst } = getStartAndEndJstDateTime();
+      const { dateNowUtc, nextSundayUtc } = getStartAndEndUtcDateTime();
       await tx.quest.updateMany({
         data: {
-          startDate: dateNowJst,
-          endDate: nextSundayJst,
+          startDate: dateNowUtc,
+          endDate: nextSundayUtc,
           weeklyCompletionCount: 0,
         },
       });

--- a/src/cron-job/quest.ts
+++ b/src/cron-job/quest.ts
@@ -4,7 +4,7 @@ import { logger } from "../pkg/logger";
 import { getStartAndEndUtcDateTime } from "../model/funcs/dateTime";
 
 const updateEveryDay = () => {
-  const scheduledTime = process.env.CRON_TZ === "UTC" ? "59 59 14 * * *" : "59 59 23 * * *";
+  const scheduledTime = process.env.CRON_TZ === "UTC" ? "0 0 15 * * *" : "0 0 0 * * *";
 
   cron.schedule(scheduledTime, async () => {
     await prisma.$transaction(async (tx) => {
@@ -21,7 +21,7 @@ const updateEveryDay = () => {
 };
 
 const updateEverySunday = () => {
-  const scheduledTime = process.env.CRON_TZ === "UTC" ? "59 59 14 * * 0" : "59 59 23 * * 0";
+  const scheduledTime = process.env.CRON_TZ === "UTC" ? "0 0 15 * * 0" : "0 0 0 * * 1";
 
   cron.schedule(scheduledTime, async () => {
     await prisma.$transaction(async (tx) => {

--- a/src/cron-job/weeklyReport.ts
+++ b/src/cron-job/weeklyReport.ts
@@ -5,7 +5,7 @@ import { WeeklyReportModel } from "../model/weeklyReport/weekly_report_model";
 
 const createEverySunday = () => {
   const weeklyReportModel = new WeeklyReportModel();
-  const scheduledTime = process.env.CRON_TZ === "UTC" ? "59 59 14 * * 0" : "59 59 23 * * 0";
+  const scheduledTime = process.env.CRON_TZ === "UTC" ? "0 0 15 * * 0" : "0 0 0 * * 1";
 
   cron.schedule(scheduledTime, async () => {
     logger.info("Running cron job for creating weekly reports every Sunday.");

--- a/src/model/funcs/dateTime.ts
+++ b/src/model/funcs/dateTime.ts
@@ -1,13 +1,9 @@
-const getStartAndEndJstDateTime = () => {
-  const dateNowObject = new Date();
-  const nextSundayDateObject = new Date(
-    dateNowObject.getFullYear(),
-    dateNowObject.getMonth(),
-    dateNowObject.getDate() + (6 - ((dateNowObject.getDay() + 6) % 7)),
-  );
-  const dateNowJst = dateNowObject.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
-  const nextSundayJst = nextSundayDateObject.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
-  return { dateNowJst, nextSundayJst };
+import { formatDateTimeOnlyDate, getNextSunday, now } from "../../pkg/dayjs";
+
+const getStartAndEndUtcDateTime = () => {
+  const dateNowUtc = formatDateTimeOnlyDate(now());
+  const nextSundayUtc = getNextSunday(dateNowUtc);
+  return { dateNowUtc, nextSundayUtc };
 };
 
-export { getStartAndEndJstDateTime };
+export { getStartAndEndUtcDateTime };

--- a/src/model/funcs/dateTime.ts
+++ b/src/model/funcs/dateTime.ts
@@ -1,8 +1,8 @@
-import { formatDateTimeOnlyDate, getNextSunday, now } from "../../pkg/dayjs";
+import { getNextSunday, now } from "../../pkg/dayjs";
 
 const getStartAndEndUtcDateTime = () => {
-  const dateNowUtc = formatDateTimeOnlyDate(now());
-  const nextSundayUtc = getNextSunday(dateNowUtc);
+  const dateNowUtc = now();
+  const nextSundayUtc = getNextSunday(dateNowUtc).format();
   return { dateNowUtc, nextSundayUtc };
 };
 

--- a/src/model/quest/quest_model.ts
+++ b/src/model/quest/quest_model.ts
@@ -2,7 +2,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../../db/db";
 import { PrismaClientWithTx } from "../../db/types";
 import { now } from "../../pkg/dayjs";
-import { getStartAndEndJstDateTime } from "../funcs/dateTime";
+import { getStartAndEndUtcDateTime } from "../funcs/dateTime";
 import { Quest } from "./types";
 
 export class QuestModel {
@@ -36,7 +36,7 @@ export class QuestModel {
     userId: string,
     tx: PrismaClientWithTx,
   ): Promise<Quest> {
-    const { dateNowJst, nextSundayJst } = getStartAndEndJstDateTime();
+    const { dateNowUtc, nextSundayUtc } = getStartAndEndUtcDateTime();
     const quest: Prisma.QuestCreateInput = {
       title: title,
       description: description,
@@ -46,8 +46,8 @@ export class QuestModel {
       tagId: tagId ?? "NO_TAG_ASSIGNED",
       state: state,
       difficulty: difficulty,
-      startDate: dateNowJst,
-      endDate: nextSundayJst,
+      startDate: dateNowUtc,
+      endDate: nextSundayUtc,
       days: days,
       weeklyFrequency: days.length,
       user: {

--- a/src/model/weeklyReport/weekly_report_model.ts
+++ b/src/model/weeklyReport/weekly_report_model.ts
@@ -1,7 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "../../db/db";
 import { PrismaClientWithTx } from "../../db/types";
-import { getStartAndEndJstDateTime } from "../funcs/dateTime";
+import { getStartAndEndUtcDateTime } from "../funcs/dateTime";
 import { WeeklyReport } from "./types";
 
 export class WeeklyReportModel {
@@ -14,15 +14,15 @@ export class WeeklyReportModel {
     tx: PrismaClientWithTx,
   ): Promise<WeeklyReport> {
     const completedPercentage = failedQuests === 0 ? 0 : (completedQuests / (completedQuests + failedQuests)) * 100;
-    const { dateNowJst, nextSundayJst } = getStartAndEndJstDateTime();
+    const { dateNowUtc, nextSundayUtc } = getStartAndEndUtcDateTime();
     const weeklyReport: Prisma.WeeklyReportCreateInput = {
       completedQuests: completedQuests,
       failedQuests: failedQuests,
       completedPercentage: completedPercentage,
       completedDays: completedDays,
       completedQuestsEachDay: completedQuestsEachDay,
-      startDate: dateNowJst,
-      endDate: nextSundayJst,
+      startDate: dateNowUtc,
+      endDate: nextSundayUtc,
       user: {
         connect: {
           id: userId,

--- a/src/pkg/dayjs.ts
+++ b/src/pkg/dayjs.ts
@@ -41,9 +41,7 @@ export const getDayOfWeekNumber = () => {
 
 export const getNextSunday = (dateTimeString: string) => {
   const dayOfTheWeekNumber = dayjs(dateTimeString).day();
-  return dayjs(dateTimeString)
-    .add(6 - ((dayOfTheWeekNumber + 6) % 7), "d")
-    .format("YYYY-MM-DD");
+  return dayjs(dateTimeString).add(6 - ((dayOfTheWeekNumber + 6) % 7), "d");
 };
 
 export const isBefore = (dateTimeString: string) => {

--- a/src/pkg/dayjs.ts
+++ b/src/pkg/dayjs.ts
@@ -35,6 +35,17 @@ export const getDayOfWeek = () => {
   return dayjs().format("ddd");
 };
 
+export const getDayOfWeekNumber = () => {
+  return dayjs().day();
+};
+
+export const getNextSunday = (dateTimeString: string) => {
+  const dayOfTheWeekNumber = dayjs(dateTimeString).day();
+  return dayjs(dateTimeString)
+    .add(6 - ((dayOfTheWeekNumber + 6) % 7), "d")
+    .format("YYYY-MM-DD");
+};
+
 export const isBefore = (dateTimeString: string) => {
   return dayjs().isBefore(dayjs(dateTimeString));
 };

--- a/src/route/middlewares/requestsLogger.ts
+++ b/src/route/middlewares/requestsLogger.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from "express";
+import { logger } from "../../pkg/logger";
+
+export const requestLogger = (req: Request, res: Response, next: NextFunction) => {
+  logger.info(
+    `METHOD: ${req.method} URL: ${req.originalUrl} STATUS: ${res.statusCode} IP: ${req.ip} USER_AGENT: ${req.get(
+      "User-Agent",
+    )}`,
+  );
+  next();
+};

--- a/src/route/middlewares/requestsLogger.ts
+++ b/src/route/middlewares/requestsLogger.ts
@@ -1,11 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { logger } from "../../pkg/logger";
 
-export const requestLogger = (req: Request, res: Response, next: NextFunction) => {
-  logger.info(
-    `METHOD: ${req.method} URL: ${req.originalUrl} STATUS: ${res.statusCode} IP: ${req.ip} USER_AGENT: ${req.get(
-      "User-Agent",
-    )}`,
-  );
+export const requestsLogger = (req: Request, res: Response, next: NextFunction) => {
+  logger.info(`[${req.method}] ${res.statusCode} "${req.originalUrl}" ip:[${req.ip}]`);
   next();
 };

--- a/src/service/weeklyReport/get_weekly_report_summary_service.ts
+++ b/src/service/weeklyReport/get_weekly_report_summary_service.ts
@@ -3,6 +3,7 @@ import { WeeklyReportModel } from "../../model/weeklyReport/weekly_report_model"
 import { HttpError } from "../../pkg/httpError";
 import { WeeklyReport } from "@prisma/client";
 import "dotenv/config";
+import { isBefore } from "../../pkg/dayjs";
 
 const runGemini = async (weeklyReports: WeeklyReport[]) => {
   const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY as string);
@@ -48,20 +49,27 @@ export const getWeeklyReportSummaryService = async (inputDTO: {
   const thisWeekReport = weeklyReports[inputDTO.weeklyReportIndex]; // 今週の週次レポート
   const lastWeekReport = weeklyReports[inputDTO.weeklyReportIndex + 1]; // 先週の週次レポート
 
-  // summaryが空文字でない場合はそれを返す
-  if (thisWeekReport.summary !== "") {
-    return thisWeekReport.summary;
+  // 週の途中の場合
+  if (!isBefore(thisWeekReport.endDate)) {
+    return "一週間が終了するとアドバイスが生成されます!";
   }
-  // 最初の週の場合
-  else if (lastWeekReport === undefined) {
-    const firstSummary = "最初の１週間お疲れさまでした！来週以降アドバイスが生成されます！";
-    await model.saveSummary(thisWeekReport.id, firstSummary);
-    return firstSummary;
-  }
-  // summaryが空文字の場合は要約を生成し、DBに保存する
+  // 終了した週の場合
   else {
-    const summary = await runGemini([thisWeekReport, lastWeekReport]);
-    await model.saveSummary(thisWeekReport.id, summary);
-    return summary;
+    // summaryが空文字でない場合はそれを返す
+    if (thisWeekReport.summary !== "") {
+      return thisWeekReport.summary;
+    }
+    // 最初の週の場合
+    else if (lastWeekReport === undefined) {
+      const firstSummary = "最初の１週間お疲れさまでした!来週も頑張りましょう!";
+      await model.saveSummary(thisWeekReport.id, firstSummary);
+      return firstSummary;
+    }
+    // summaryが空文字の場合は要約を生成し、DBに保存する
+    else {
+      const summary = await runGemini([thisWeekReport, lastWeekReport]);
+      await model.saveSummary(thisWeekReport.id, summary);
+      return summary;
+    }
   }
 };


### PR DESCRIPTION
## 関連 issue

## 説明
今までの実装だと、週の途中でもsummaryが生成されてしまいましたが、現在時刻がendDateより後の場合のみ生成するように修正しました。
## 動作確認手順

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
