### PR TITLE
[Service] 週次レポートの％が更新されないバグの修正

### DIFF
--- a/src/model/weeklyReport/weekly_report_model.ts
+++ b/src/model/weeklyReport/weekly_report_model.ts
@@ -66,6 +66,7 @@ export class WeeklyReportModel {
     });
     return result;
   }
+
   public async getByUserId(userId: string): Promise<WeeklyReport | null> {
     const result = await prisma.weeklyReport.findFirst({
       // 最新の週報を取得
@@ -81,19 +82,21 @@ export class WeeklyReportModel {
 
   public async updateByIdWithTx(
     id: string,
-    completedQuestsIncrements: number,
-    failedQuestsIncrements: number,
-    completedDaysIncrements: number,
+    completedQuests: number,
+    failedQuests: number,
+    completedDays: number,
     completedQuestsEachDay: number[],
+    completedPercentage: number,
     tx: PrismaClientWithTx,
   ): Promise<WeeklyReport> {
     const result = await tx.weeklyReport.update({
       where: { id: id },
       data: {
-        completedQuests: { increment: completedQuestsIncrements },
-        failedQuests: { increment: failedQuestsIncrements },
-        completedDays: { increment: completedDaysIncrements },
+        completedQuests: completedQuests,
+        failedQuests: failedQuests,
+        completedDays: completedDays,
         completedQuestsEachDay: completedQuestsEachDay,
+        completedPercentage: completedPercentage,
       },
     });
     return result;

--- a/src/service/quest/finish_quest_service.ts
+++ b/src/service/quest/finish_quest_service.ts
@@ -37,17 +37,21 @@ export const finishQuestService = async (inputDTO: InputDTO) => {
 
     // 週次レポートの更新
     const completedQuestsIncrements = 1;
-    const failedQuestsIncrements = 0;
-    const completedDaysIncrements = 0;
+
+    const completedQuests = targetWeeklyReport.completedQuests + completedQuestsIncrements;
+    const failedQuests = targetWeeklyReport.failedQuests;
+    const completedDays = targetWeeklyReport.completedDays;
+    const completedPercentage = Math.floor((completedQuests / (completedQuests + failedQuests)) * 100);
     const index = (new Date().getDay() + 6) % 7; // 0: 月曜日, 1: 火曜日...
     targetWeeklyReport.completedQuestsEachDay[index] += 1;
 
     const weeklyReport = await weeklyReportModel.updateByIdWithTx(
       targetWeeklyReport.id,
-      completedQuestsIncrements,
-      failedQuestsIncrements,
-      completedDaysIncrements,
+      completedQuests,
+      failedQuests,
+      completedDays,
       targetWeeklyReport.completedQuestsEachDay,
+      completedPercentage,
       tx,
     );
     if (!weeklyReport) {

--- a/src/service/quest/force_finish_quest_service.ts
+++ b/src/service/quest/force_finish_quest_service.ts
@@ -29,18 +29,25 @@ export const forceFinishQuestService = async (inputDTO: InputDTO) => {
     }
 
     // 週次レポートの更新
-    const completedQuestsIncrements = 0;
     const failedQuestsIncrements = 1;
-    const completedDaysIncrements = 0;
+
+    const completedQuests = targetWeeklyReport.completedQuests;
+    const failedQuests = targetWeeklyReport.failedQuests + failedQuestsIncrements;
+    const completedDays = 0;
+    const completedPercentage = Math.floor((completedQuests / (completedQuests + failedQuests)) * 100);
 
     const weeklyReport = await weeklyReportModel.updateByIdWithTx(
       targetWeeklyReport.id,
-      completedQuestsIncrements,
-      failedQuestsIncrements,
-      completedDaysIncrements,
+      completedQuests,
+      failedQuests,
+      completedDays,
       targetWeeklyReport.completedQuestsEachDay,
+      completedPercentage,
       tx,
     );
+    if (!weeklyReport) {
+      throw new HttpError("週報の更新に失敗しました", 500);
+    }
 
     return {
       id: forceFinishedQuest.id,


### PR DESCRIPTION
## 関連 issue
- #69 

## 説明
- クエスト終了、強制終了時にパーセンテージが更新されないバグの修正です。※コンプリート日数も更新されないですが、それは次のissueで。

## 動作確認手順
- いつも通り、動かせます。

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
