### PR TITLE
[Service] 経験値増加計算のための引数のミスを修正

### DIFF
--- a/src/service/quest/finish_quest_service.ts
+++ b/src/service/quest/finish_quest_service.ts
@@ -30,7 +30,7 @@ export const finishQuestService = async (inputDTO: InputDTO) => {
       throw new HttpError("クエストの完了に失敗しました", 500);
     }
 
-    const targetWeeklyReport = await weeklyReportModel.getByUserId(finishedQuest.userId);
+    const targetWeeklyReport = await weeklyReportModel.getByUserId(quest.userId);
     if (!targetWeeklyReport) {
       throw new HttpError("指定したuserIdの週報が存在しません", 400);
     }
@@ -59,12 +59,12 @@ export const finishQuestService = async (inputDTO: InputDTO) => {
     }
 
     //ユーザーの経験値とレベルを更新
-    const user = await userModel.getById(finishedQuest.userId);
+    const user = await userModel.getById(quest.userId);
     if (!user) {
       throw new HttpError("ユーザーが見つかりません", 400);
     }
 
-    const expIncrement = getQuestExp(finishedQuest.difficulty, finishedQuest.continuationLevel);
+    const expIncrement = getQuestExp(quest.difficulty, quest.continuationLevel);
     const updatedUser = await userModel.updateExpWithTx(user.id, user.exp, expIncrement, tx);
     if (!updatedUser) {
       throw new HttpError("ユーザーの経験値の更新に失敗しました", 500);

--- a/src/service/quest/force_finish_quest_service.ts
+++ b/src/service/quest/force_finish_quest_service.ts
@@ -23,7 +23,7 @@ export const forceFinishQuestService = async (inputDTO: InputDTO) => {
       throw new HttpError("クエストの完了に失敗しました", 500);
     }
 
-    const targetWeeklyReport = await weeklyReportModel.getByUserId(forceFinishedQuest.userId);
+    const targetWeeklyReport = await weeklyReportModel.getByUserId(quest.userId);
     if (!targetWeeklyReport) {
       throw new HttpError("指定したuserIdの週報が存在しません", 400);
     }


### PR DESCRIPTION
## 関連 issue

## 説明
- 経験値増加計算のための引数がクエスト更新後の継続レベルを渡してしまっていたため、正しく値が反映されなかった。クエスト更新前のものを渡すように修正。

## 動作確認手順

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
