### PR TITLE
fix: Achieve BadgeにHttpErrorの追加

### DIFF
--- a/src/service/badge/achieve_badge_service.ts
+++ b/src/service/badge/achieve_badge_service.ts
@@ -1,14 +1,28 @@
 import { prisma } from "../../db/db";
 import { BadgeModel } from "../../model/badge/badge_model";
+import { BadgeDetailModel } from "../../model/badgeDetail/badge_detail_model";
+import { UserModel } from "../../model/user/user_model";
+import { HttpError } from "../../pkg/httpError";
 
 export const achieveBadgeService = async (inputDTO: {
   badgeId: string;
   userId: string;
 }) => {
   return prisma.$transaction(async (tx) => {
-    const model = new BadgeModel();
+    const badgeModel = new BadgeModel();
+    const badgeDetailModel = new BadgeDetailModel();
+    const userModel = new UserModel();
 
-    const badge = await model.achieveWithTx(inputDTO.badgeId, inputDTO.userId, tx);
+    const badgeDetail = await badgeDetailModel.getById(inputDTO.badgeId);
+    if (!badgeDetail) {
+      throw new HttpError("バッジ詳細が見つかりません", 400);
+    }
+    const user = await userModel.getById(inputDTO.userId);
+    if (!user) {
+      throw new HttpError("ユーザーが見つかりません", 400);
+    }
+
+    const badge = await badgeModel.achieveWithTx(inputDTO.badgeId, inputDTO.userId, tx);
 
     return {
       id: badge.id,


### PR DESCRIPTION
## 関連 issue

## 説明
Achieve badge serviceにて、存在しないユーザー、バッジを参照したときにエラーを返すように修正しました。
## 動作確認手順

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
